### PR TITLE
Centralize dependency management with shared requirements file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,9 +5,11 @@ ENV LANG=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
+COPY requirements.txt /tmp/requirements.txt
+
 RUN apt update -qq && \
     apt install -qq -y pkg-config libhdf5-dev gcc git ffmpeg imagemagick && \
-    pip install -q tensorflow==2.16.1 && \
+    pip install -q -r /tmp/requirements.txt && \
     pip install -q git+https://github.com/aayars/py-noisemaker && \
     apt remove -qq --purge -y pkg-config gcc git && \
     apt autoremove -qq -y && \

--- a/py_noisemaker.ipynb
+++ b/py_noisemaker.ipynb
@@ -45,8 +45,8 @@
       },
       "source": [
         "!git clone https://github.com/aayars/py-noisemaker.git\n",
-        "!cd py-noisemaker && pip install .\n",
-        "!pip install tensorflow==2.16.1"
+        "!pip install -r py-noisemaker/requirements.txt\n",
+        "!cd py-noisemaker && pip install ."
       ],
       "execution_count": null,
       "outputs": []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+absl-py>=0.9,<2.2
+click==8.1.7
+colorthief==0.2.1
+h5py>=3.10.0
+loguru==0.7.2
+opensimplex==0.3
+pillow>=10.0.1,<11
+protobuf>=4.25.8,<7
+requests>=2.4.2
+six>=1.15,<1.17
+wheel==0.45.1
+tensorflow==2.16.1

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,17 @@
 #!/usr/bin/env python
 
-from setuptools import setup, find_packages
+from pathlib import Path
 
-setup(name='noisemaker',
+from setuptools import find_packages, setup
+
+def read_requirements():
+    reqs_path = Path(__file__).with_name("requirements.txt")
+    with reqs_path.open() as f:
+        return [line.strip() for line in f if line.strip() and not line.startswith("#")]
+
+
+setup(
+      name='noisemaker',
       version='0.5.0',
       description='Generates procedural noise with Python 3 and TensorFlow',
       author='Alex Ayars',
@@ -17,20 +26,7 @@ setup(name='noisemaker',
         noisemaker=noisemaker.scripts.noisemaker:main
         ''',
 
-      install_requires=[
-        "absl-py>=0.9,<2.2",
-        "click==8.1.7",
-        "colorthief==0.2.1",
-        "h5py>=3.10.0",
-        "loguru==0.7.2",
-        "opensimplex==0.3",
-        "pillow>=10.0.1,<11",
-        "protobuf>=4.25.8,<7",
-        "requests>=2.4.2",
-        "six>=1.15,<1.17",
-        "wheel==0.45.1",  # Needed by TF
-        ],
-
+      install_requires=read_requirements(),
       tests_require=["pytest==8.4.1"],
       )
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist = py37, py38, py39, py310
 
 [testenv]
 deps =
-    pytest==8.2.0
-    tensorflow==2.16.1
+    -rrequirements.txt
+    pytest==8.4.1
 
 commands =
     pytest


### PR DESCRIPTION
## Summary
- load install requirements from shared `requirements.txt`
- configure tox to install dependencies from the same requirements file

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4c632336c83208e7959e9b13fd962