### PR TITLE
Fix color normalization in JS port

### DIFF
--- a/src/value.js
+++ b/src/value.js
@@ -707,19 +707,17 @@ export function blend(a, b, t) {
 export function normalize(tensor) {
   const [h, w, c] = tensor.shape;
   const src = tensor.read();
+  let min = Infinity;
+  let max = -Infinity;
+  for (let i = 0; i < src.length; i++) {
+    const v = src[i];
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  const range = max - min || 1;
   const out = new Float32Array(src.length);
-  for (let k = 0; k < c; k++) {
-    let min = Infinity;
-    let max = -Infinity;
-    for (let i = k; i < src.length; i += c) {
-      const v = src[i];
-      if (v < min) min = v;
-      if (v > max) max = v;
-    }
-    const range = max - min || 1;
-    for (let i = k; i < src.length; i += c) {
-      out[i] = (src[i] - min) / range;
-    }
+  for (let i = 0; i < src.length; i++) {
+    out[i] = (src[i] - min) / range;
   }
   return Tensor.fromArray(tensor.ctx, out, [h, w, c]);
 }

--- a/test/value.test.js
+++ b/test/value.test.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { values, downsample, upsample, blend, sobel, valueMap, hsvToRgb, rgbToHsv, warp, fft, ifft, refract, convolution, ridge, rotate, zoom, fxaa, gaussianBlur, freqForShape } from '../src/value.js';
+import { values, downsample, upsample, blend, sobel, valueMap, hsvToRgb, rgbToHsv, warp, fft, ifft, refract, convolution, ridge, rotate, zoom, fxaa, gaussianBlur, freqForShape, normalize } from '../src/value.js';
 import { rgbToOklab, oklabToRgb } from '../src/oklab.js';
 import { ValueDistribution, ValueMask, InterpolationType } from '../src/constants.js';
 import { Tensor } from '../src/tensor.js';
@@ -162,6 +162,13 @@ const palette = [[0,0,0],[1,0,0],[0,1,0],[0,0,1]];
 const mapped = valueMap(gray, palette);
 assert.deepStrictEqual(mapped.shape, [2, 2, 3]);
 assert.deepStrictEqual(Array.from(mapped.read().slice(0,3)), palette[0]);
+
+// normalize should use global min/max across channels
+const normMulti = Tensor.fromArray(null, new Float32Array([0, 1, 2, 3, 4, 5]), [1, 2, 3]);
+arraysClose(
+  normalize(normMulti).read(),
+  new Float32Array([0, 0.2, 0.4, 0.6, 0.8, 1])
+);
 
 // color conversions
 const rgb = Tensor.fromArray(null, new Float32Array([1, 0, 0]), [1, 1, 3]);


### PR DESCRIPTION
## Summary
- use global min/max in `normalize` to preserve channel relationships
- add regression test verifying multi-channel normalization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0ec1f0a4c8320acf92ada80c87ee9