### PR TITLE
[codex] Add lighting height map input

### DIFF
--- a/shaders/effects/filter/lighting/definition.js
+++ b/shaders/effects/filter/lighting/definition.js
@@ -147,6 +147,14 @@ export default new Effect({
         category: "reflection",
         enabledBy: { param: "reflection", gt: 0 }
       }
+    },
+    heightMap: {
+      type: "surface",
+      default: "inputTex",
+      ui: {
+        label: "height map",
+        category: "general"
+      }
     }
   },
   defaultProgram: "search filter, synth\n\nnoise(ridges: true)\n.lighting(normalStrength: 2)\n.write(o0)",
@@ -155,7 +163,8 @@ export default new Effect({
       name: "render",
       program: "lighting",
       inputs: {
-        inputTex: "inputTex"
+        inputTex: "inputTex",
+        heightMap: "heightMap"
       },
       outputs: {
         fragColor: "outputTex"

--- a/shaders/effects/filter/lighting/glsl/lighting.glsl
+++ b/shaders/effects/filter/lighting/glsl/lighting.glsl
@@ -9,6 +9,7 @@ precision highp float;
 #endif
 
 uniform sampler2D inputTex;
+uniform sampler2D heightMap;
 uniform vec2 tileOffset;
 uniform vec2 fullResolution;
 uniform vec3 diffuseColor;
@@ -29,6 +30,12 @@ out vec4 fragColor;
 // Convert RGB to luminosity
 float getLuminosity(vec3 color) {
     return dot(color, vec3(0.299, 0.587, 0.114));
+}
+
+float getHeight(vec2 uv) {
+    vec2 mapSize = vec2(textureSize(heightMap, 0));
+    vec2 localUV = (uv * fullResolution - tileOffset) / mapSize;
+    return getLuminosity(texture(heightMap, localUV).rgb);
 }
 
 // Calculate surface normal from height map using Sobel convolution
@@ -63,8 +70,7 @@ vec3 calculateNormal(vec2 uv, vec2 texelSize) {
     float dy = 0.0;
     
     for (int i = 0; i < 9; i++) {
-        vec3 texSample = texture(inputTex, ((uv + offsets[i]) * fullResolution - tileOffset) / vec2(textureSize(inputTex, 0))).rgb;
-        float height = getLuminosity(texSample);
+        float height = getHeight(uv + offsets[i]);
         dx += height * sobel_x[i];
         dy += height * sobel_y[i];
     }

--- a/shaders/effects/filter/lighting/wgsl/lighting.wgsl
+++ b/shaders/effects/filter/lighting/wgsl/lighting.wgsl
@@ -21,11 +21,16 @@ struct Uniforms {
 
 @group(0) @binding(0) var inputSampler: sampler;
 @group(0) @binding(1) var inputTex: texture_2d<f32>;
-@group(0) @binding(2) var<uniform> uniforms: Uniforms;
+@group(0) @binding(2) var heightMap: texture_2d<f32>;
+@group(0) @binding(3) var<uniform> uniforms: Uniforms;
 
 // Convert RGB to luminosity
 fn getLuminosity(color: vec3f) -> f32 {
     return dot(color, vec3f(0.299, 0.587, 0.114));
+}
+
+fn getHeight(uv: vec2f) -> f32 {
+    return getLuminosity(textureSample(heightMap, inputSampler, uv).rgb);
 }
 
 // Calculate surface normal from height map using Sobel convolution
@@ -63,8 +68,7 @@ fn calculateNormal(uv: vec2f, texelSize: vec2f) -> vec3f {
     var dy: f32 = 0.0;
     
     for (var i: i32 = 0; i < 9; i = i + 1) {
-        let sample = textureSample(inputTex, inputSampler, uv + offsets[i]);
-        let height = getLuminosity(sample.rgb);
+        let height = getHeight(uv + offsets[i]);
         dx += height * sobel_x[i];
         dy += height * sobel_y[i];
     }

--- a/shaders/effects/strings.en.json
+++ b/shaders/effects/strings.en.json
@@ -1523,6 +1523,7 @@
   "filter/lighting.aberration": "aberration",
   "filter/lighting.ambientColor": "ambient",
   "filter/lighting.diffuseColor": "color",
+  "filter/lighting.heightMap": "height map",
   "filter/lighting.lightDirection": "direction",
   "filter/lighting.normalStrength": "depth",
   "filter/lighting.reflection": "reflection",

--- a/shaders/src/runtime/expander.js
+++ b/shaders/src/runtime/expander.js
@@ -3,6 +3,11 @@ import { stdEnums } from '../lang/std_enums.js'
 import { expandPalette } from './palette-expansion.js'
 
 const SURFACE_REF_PATTERN = /^(?:o|vol|geo|xyz|vel|rgba)[0-7]$/
+const TEXTURE_ARG_KINDS = new Set(['temp', 'output', 'source', 'feedback', 'vol', 'geo', 'xyz', 'vel', 'rgba', 'pipeline'])
+
+function isTextureArg(arg) {
+    return arg !== null && typeof arg === 'object' && TEXTURE_ARG_KINDS.has(arg.kind)
+}
 
 /** Register passthrough outputs for a node that doesn't generate passes */
 function registerPassthrough(nodeId, textureMap, currentInput, currentInput3d, currentInputGeo, currentInputXyz, currentInputVel, currentInputRgba) {
@@ -563,11 +568,9 @@ export function expand(compilationResult, options = {}) {
             // being set to its default before we know if a surface is provided
             if (step.args) {
                 for (const [argName, arg] of Object.entries(step.args)) {
-                    const isObjectArg = arg !== null && typeof arg === 'object'
-
                     // Handle surface arguments that may resolve to 'none'
                     // If the global has a colorModeUniform, set it based on whether surface is 'none'
-                    if (isObjectArg && (arg.kind === 'temp' || arg.kind === 'output' || arg.kind === 'source' || arg.kind === 'feedback' || arg.kind === 'xyz' || arg.kind === 'vel' || arg.kind === 'rgba')) {
+                    if (isTextureArg(arg)) {
                         // Check if this global has a colorModeUniform property
                         const globalDef = effectDef.globals?.[argName]
                         if (globalDef?.colorModeUniform) {
@@ -586,7 +589,7 @@ export function expand(compilationResult, options = {}) {
                     const isObjectArg = arg !== null && typeof arg === 'object'
 
                     // Skip surface arguments (already processed in first pass)
-                    if (isObjectArg && (arg.kind === 'temp' || arg.kind === 'output' || arg.kind === 'source' || arg.kind === 'feedback' || arg.kind === 'xyz' || arg.kind === 'vel' || arg.kind === 'rgba')) {
+                    if (isTextureArg(arg)) {
                         continue
                     }
 
@@ -713,7 +716,7 @@ export function expand(compilationResult, options = {}) {
                         const isObjectArg = arg !== null && typeof arg === 'object'
 
                         // Skip texture arguments (handled in inputs)
-                        if (isObjectArg && (arg.kind === 'temp' || arg.kind === 'output' || arg.kind === 'source' || arg.kind === 'feedback' || arg.kind === 'xyz' || arg.kind === 'vel' || arg.kind === 'rgba')) {
+                        if (isTextureArg(arg)) {
                             continue
                         }
 
@@ -875,6 +878,8 @@ export function expand(compilationResult, options = {}) {
 
                             if (arg.kind === 'temp') {
                                 pass.inputs[uniformName] = textureMap.get(`node_${arg.index}_out`)
+                            } else if (arg.kind === 'pipeline' && (arg.name === 'inputTex' || arg.name === 'inputColor')) {
+                                pass.inputs[uniformName] = currentInput || arg.name
                             } else if (arg.kind === 'output' || arg.kind === 'source' || arg.kind === 'vol' ||
                                        arg.kind === 'geo' || arg.kind === 'xyz' || arg.kind === 'vel' || arg.kind === 'rgba') {
                                 pass.inputs[uniformName] = arg.name === 'none' ? 'none' : `global_${arg.name}`

--- a/shaders/tests/test_lighting_height_map.js
+++ b/shaders/tests/test_lighting_height_map.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict'
+
+import Lighting from '../effects/filter/lighting/definition.js'
+import { registerOp } from '../src/lang/ops.js'
+import { registerStarterOps } from '../src/lang/validator.js'
+import { compileGraph } from '../src/runtime/compiler.js'
+import { registerEffect } from '../src/runtime/registry.js'
+
+registerOp('synth.solid', {
+    name: 'solid',
+    args: []
+})
+
+registerOp('synth.wave', {
+    name: 'wave',
+    args: []
+})
+
+registerOp('filter.lighting', {
+    name: 'lighting',
+    args: Object.entries(Lighting.globals).map(([name, def]) => ({
+        name,
+        type: def.type,
+        default: def.default
+    }))
+})
+
+registerStarterOps(['synth.solid', 'synth.wave'])
+
+registerEffect('synth.solid', {
+    name: 'Solid',
+    namespace: 'synth',
+    func: 'solid',
+    passes: [
+        {
+            name: 'main',
+            type: 'render',
+            program: 'solid',
+            inputs: {},
+            outputs: { color: 'outputTex' }
+        }
+    ]
+})
+
+registerEffect('synth.wave', {
+    name: 'Wave',
+    namespace: 'synth',
+    func: 'wave',
+    passes: [
+        {
+            name: 'main',
+            type: 'render',
+            program: 'wave',
+            inputs: {},
+            outputs: { color: 'outputTex' }
+        }
+    ]
+})
+
+registerEffect('filter.lighting', Lighting)
+
+const tests = []
+
+function test(name, fn) {
+    tests.push({ name, fn })
+}
+
+function lightingPass(graph) {
+    const pass = graph.passes.find((candidate) => candidate.effectKey === 'filter.lighting')
+    assert.ok(pass, 'compiled graph should include a lighting pass')
+    return pass
+}
+
+test('lighting defaults heightMap to the current input texture', () => {
+    const graph = compileGraph('search synth, filter\nsolid().lighting().write(o0)')
+    const pass = lightingPass(graph)
+
+    assert.equal(pass.inputs.inputTex, 'node_0_out')
+    assert.equal(pass.inputs.heightMap, 'node_0_out')
+    assert.equal('heightMap' in pass.uniforms, false)
+})
+
+test('lighting can sample normals from an explicit heightMap surface', () => {
+    const graph = compileGraph('search synth, filter\nsolid().write(o0)\nwave().lighting(heightMap: read(o0)).write(o1)')
+    const pass = lightingPass(graph)
+
+    assert.equal(pass.inputs.inputTex, 'node_2_out')
+    assert.equal(pass.inputs.heightMap, 'global_o0')
+    assert.equal('heightMap' in pass.uniforms, false)
+})
+
+test('lighting keeps positional normalStrength backwards compatible', () => {
+    const graph = compileGraph('search synth, filter\nsolid().lighting(2).write(o0)')
+    const pass = lightingPass(graph)
+
+    assert.equal(pass.uniforms.normalStrength, 2)
+    assert.equal(pass.inputs.heightMap, 'node_0_out')
+    assert.equal('heightMap' in pass.uniforms, false)
+})
+
+let passed = 0
+let failed = 0
+
+for (const { name, fn } of tests) {
+    try {
+        fn()
+        console.log(`PASS: ${name}`)
+        passed++
+    } catch (error) {
+        console.error(`FAIL: ${name}`)
+        console.error(error)
+        failed++
+    }
+}
+
+console.log(`\n${passed} passed, ${failed} failed`)
+
+if (failed > 0) {
+    process.exit(1)
+}


### PR DESCRIPTION
## Summary

Adds an optional `heightMap` surface to `filter/lighting` so normals can be computed from a separate texture. When omitted, `heightMap` defaults to the current input texture, preserving the previous luminosity-derived normal behavior.

The review feedback is addressed by keeping `heightMap` at the end of the lighting globals, so positional calls like `.lighting(2)` still set `normalStrength`. Texture-like pipeline defaults are also skipped during uniform mapping so `heightMap` routes as an input texture instead of leaking into uniforms.

## Validation

- `node shaders/tests/test_lighting_height_map.js`
- `node shaders/tests/test_effect_strings.mjs`
- `node shaders/tests/test-harness.js --structure-only --effects filter/lighting --backend webgl2`
- `node shaders/tests/test-harness.js --effects filter/lighting --backend webgl2`
- `node shaders/tests/test-harness.js --effects filter/lighting --backend webgpu`
- `npm run test:shaders:lang`
- `git diff --check`